### PR TITLE
USA Communist/Democratic advisors change

### DIFF
--- a/common/ideas/usa.txt
+++ b/common/ideas/usa.txt
@@ -1423,10 +1423,9 @@ ideas = {
 				}
 				NOT = {
 					has_idea_with_trait = fascist_demagogue
+					has_idea_with_trait = democratic_reformer
 				}			
 			}
-
-			removal_cost = 200	
 			
 			traits = { communist_revolutionary }
 
@@ -1667,8 +1666,11 @@ ideas = {
 					limit = { has_dlc = "Man the Guns" }	
 					NOT = { has_autonomy_state = autonomy_supervised_state }
 				}
+				NOT = {
+					has_idea_with_trait = communist_revolutionary
+				}	
 			}
-			
+
 			traits = { democratic_reformer }
 	
 			do_effect = {


### PR DESCRIPTION
Communist and Democratic boosting advisors for the USA are now locked from going back and forth; while there's already a thing in place to make communist boosting advisor "expensive" to remove, this actually punishes both lite-communist and full communist USAs as the removal cost applies to **everything**
![image](https://user-images.githubusercontent.com/18253120/127703867-f82cb056-2df7-4406-9f49-3dcfa3bbd356.png)
